### PR TITLE
fix: Do not generate code from broken protocol files.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
@@ -4,6 +4,7 @@ import 'package:serverpod_cli/src/util/protocol_helper.dart';
 
 class _ProtocolState {
   ProtocolSource source;
+  List<SourceSpanException> errors = [];
   SerializableEntityDefinition? entity;
 
   _ProtocolState({
@@ -38,6 +39,13 @@ class StatefulAnalyzer {
     _validateAllProtocols();
     return _entities;
   }
+
+  /// Returns all valid entities in the state.
+  List<SerializableEntityDefinition> get validEntities => _protocolStates.values
+      .where((state) => state.errors.isEmpty)
+      .map((state) => state.entity)
+      .whereType<SerializableEntityDefinition>()
+      .toList();
 
   /// Runs the validation on a single protocol. The protocol must exist in the
   /// state, if not this returns the last validated state.
@@ -109,6 +117,12 @@ class StatefulAnalyzer {
         state.entity,
         _entities,
       );
+
+      if (collector.hasSeverErrors) {
+        state.errors = collector.errors;
+      } else {
+        state.errors = [];
+      }
 
       _onErrorsChangedNotifier?.call(
         Uri.file(state.source.yamlSourceUri.path),


### PR DESCRIPTION
# Fix

Needs https://github.com/serverpod/serverpod/pull/1219 to function.

Crashes on invalid protocol files fixed by ignoring protocol files that have errors.

Resolves: https://github.com/serverpod/serverpod/issues/1164

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

